### PR TITLE
Exclude hack from update-deps

### DIFF
--- a/deps-exclude.yaml
+++ b/deps-exclude.yaml
@@ -3,3 +3,4 @@
 - "knative-sandbox/homebrew-kn-plugins"
 - "knative-sandbox/kn-plugin-func"
 - "knative-sandbox/.github"
+- "knative/hack"


### PR DESCRIPTION
It appears it doesn't work with a go.mod file with no deps, but it's pointless to run it anyway.

https://github.com/knative-sandbox/knobots/actions/runs/1385746917