### PR TITLE
Adjust the target release to be v1.0

### DIFF
--- a/actions/update-deps/action.yaml
+++ b/actions/update-deps/action.yaml
@@ -35,5 +35,5 @@ runs:
     # CHANGE THIS LINE AFTER RELEASE
     # This should point to the _upcoming_ release
     # *******************************************
-    RELEASE: ${{ inputs.release || 'v0.27' }}
+    RELEASE: ${{ inputs.release || 'v1.0' }}
     FORCE_DEPS: ${{ inputs.pr-empty-deps }}


### PR DESCRIPTION
As per title, this fixes the update deps machinery to not move pkg and friends past the branch we've already cut.