### PR TITLE
Fix update-actions omit, again

### DIFF
--- a/actions/update-actions/entrypoint.sh
+++ b/actions/update-actions/entrypoint.sh
@@ -24,7 +24,7 @@ mkdir -p "${GITHUB_WORKSPACE}/main/.github/workflows"
 cp $(find "${GITHUB_WORKSPACE}/meta/workflow-templates" -type f -name '*.yaml') \
   "${GITHUB_WORKSPACE}/main/.github/workflows"
 yaml2json < "${GITHUB_WORKSPACE}/config/actions-omitted.yaml" |
-  jq -r --arg repo "$ORGANIZATION/$REPO" '(.[$repo] // {"omit": []}).omit[]' | \
+  jq -r --arg repo "$REPO" '(.[$repo] // {"omit": []}).omit[]' | \
   while read FILE; do
     rm "${GITHUB_WORKSPACE}/main/.github/workflows/${FILE}"*
   done


### PR DESCRIPTION
"$REPO" is the full "org/repo" already, so we were getting "knative/knative/website" here.

At least my previous change that made the script run with `set -x` let me figure this out now.

https://github.com/knative-sandbox/knobots/runs/4046895687?check_suite_focus=true#step:7:115