### PR TITLE
Point to properly named workflows

### DIFF
--- a/workflow-templates/knative-go-build.yaml
+++ b/workflow-templates/knative-go-build.yaml
@@ -11,4 +11,4 @@ on:
 
 jobs:
   build:
-    uses: knative/actions/.github/workflows/go-build.yaml@main
+    uses: knative/actions/.github/workflows/reusable-go-build.yaml@main

--- a/workflow-templates/knative-go-test.yaml
+++ b/workflow-templates/knative-go-test.yaml
@@ -14,4 +14,4 @@ on:
 
 jobs:
   test:
-    uses: knative/actions/.github/workflows/go-test.yaml@main
+    uses: knative/actions/.github/workflows/reusable-go-test.yaml@main

--- a/workflow-templates/knative-releasability.yaml
+++ b/workflow-templates/knative-releasability.yaml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   releasability:
-    uses: knative/actions/.github/workflows/releasability.yaml@main
+    uses: knative/actions/.github/workflows/reusable-releasability.yaml@main
     with:
       releaseFamily: ${{ github.event.inputs.releaseFamily || 'v1.9' }}
       moduleReleaseFamily: ${{ github.event.inputs.moduleReleaseFamily || 'v0.36' }}

--- a/workflow-templates/knative-release-notes.yaml
+++ b/workflow-templates/knative-release-notes.yaml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   release-notes:
-    uses: knative/actions/.github/workflows/release-notes.yaml@main
+    uses: knative/actions/.github/workflows/reusable-release-notes.yaml@main
     with:
       branch: ${{ github.event.inputs.branch }}
       start-rev: ${{ github.event.inputs.start-rev }}

--- a/workflow-templates/knative-security.yaml
+++ b/workflow-templates/knative-security.yaml
@@ -14,4 +14,4 @@ on:
 
 jobs:
   analyze:
-    uses: knative/actions/.github/workflows/security.yaml@main
+    uses: knative/actions/.github/workflows/reusable-security.yaml@main

--- a/workflow-templates/knative-stale.yaml
+++ b/workflow-templates/knative-stale.yaml
@@ -11,4 +11,4 @@ on:
 jobs:
 
   stale:
-    uses: knative/actions/.github/workflows/stale.yaml@main
+    uses: knative/actions/.github/workflows/reusable-stale.yaml@main

--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -12,4 +12,4 @@ on:
 jobs:
 
   style:
-    uses: knative/actions/.github/workflows/style.yaml@main
+    uses: knative/actions/.github/workflows/reusable-style.yaml@main

--- a/workflow-templates/knative-verify.yaml
+++ b/workflow-templates/knative-verify.yaml
@@ -23,4 +23,4 @@ on:
 
 jobs:
   verify:
-    uses: knative/actions/.github/workflows/verify-codegen.yaml@main
+    uses: knative/actions/.github/workflows/reusable-verify-codegen.yaml@main


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes
Change templates to point to the properly `reusable-*` named convention workflows.

- :broom: Update or clean up current behavior