### PR TITLE
Add `skip-review` label on automated yaml/image bumps

### DIFF
--- a/.github/workflows/update-nightlies.yaml
+++ b/.github/workflows/update-nightlies.yaml
@@ -212,6 +212,7 @@ jobs:
           ${{ steps.nightlies.outputs.deplog }}
 
         title: '[Automated] Update ${{ matrix.nightly }} nightly'
+        labels: 'skip-review'
         body: |
           /assign ${{ matrix.assignee }}
           /cc ${{ matrix.assignee }}


### PR DESCRIPTION
See discussion in https://cloud-native.slack.com/archives/C04LY4M2G49/p1697606859044749


# Changes
Add `skip-review` label on automated yaml/image bumps to skip reviews on automated bumps of dependant YAML and images, as it makes not much sense to review them manually (these diff are not really reviewable: [changed the image](https://github.com/knative/serving/pull/14532/files#diff-98ca8086b0e104b5818b24a99727ddc62096abfa5b4e1c0f66c42948a4893c80R346))

/assign @dprotaso 
/assign @upodroid 