### PR TITLE
serving-writers shouldn't be tagged to review reconciler-test PRs

### DIFF
--- a/repos.yaml
+++ b/repos.yaml
@@ -101,7 +101,7 @@
   meta-organization: 'knative-extensions'
   fork: 'knative-automation/reconciler-test'
   channel: 'knative-eventing'
-  assignees: knative-extensions/eventing-writers knative-extensions/serving-writers
+  assignees: knative-extensions/eventing-writers
 
 # knative-extensions (samples)
 - name: 'knative-extensions/sample-controller'


### PR DESCRIPTION
Serving doesn't use this framework
