### PR TITLE
Provide helm in update-deps image

### DIFF
--- a/actions/update-deps/Dockerfile
+++ b/actions/update-deps/Dockerfile
@@ -19,6 +19,10 @@ RUN go install github.com/google/ko@latest
 RUN go install github.com/google/go-licenses@latest
 RUN go install github.com/dprotaso/modlog@latest
 RUN go install knative.dev/toolbox/buoy@latest
+RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
+    chmod 700 get_helm.sh && \
+    ./get_helm.sh && \
+    rm -f get_helm.sh
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Some of the update-deps jobs require helm to be installed (e.g. eventing or eventing-kafka-broker).

See: https://github.com/knative-extensions/knobots/actions/runs/7482975295/job/20367497039 or https://github.com/knative/eventing/blob/bc89d285177775c5e287aea32e86a502eddac80e/hack/update-cert-manager.sh#L14-L17

This PR addresses it and installs the latest helm 3 version into the update-deps image.