### PR TITLE
Add func-go to repository config

### DIFF
--- a/repos.yaml
+++ b/repos.yaml
@@ -288,6 +288,12 @@
   channel: 'knative-functions'
   assignees: 'knative-extensions/func-tastic-approvers'
 
+- name: 'knative-extensions/func-go'
+  meta-organization: 'knative-extensions'
+  fork: 'knative-automation/func-go'
+  channel: 'knative-functions'
+  assignees: 'knative/function-runtime-approvers'
+  
 # knative-extensions (backstage)
 - name: 'knative-extensions/backstage-plugins'
   meta-organization: 'knative-extensions'

--- a/repos.yaml
+++ b/repos.yaml
@@ -292,7 +292,7 @@
   meta-organization: 'knative-extensions'
   fork: 'knative-automation/func-go'
   channel: 'knative-functions'
-  assignees: 'knative/function-runtime-approvers'
+  assignees: 'knative-extensions/function-runtime-approvers'
   
 # knative-extensions (backstage)
 - name: 'knative-extensions/backstage-plugins'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- :gift: Add func-go to repository config

Per our earlier conversation on #knative-functions channel. In case we want to enable syncing various common bits, inluding GH actions, owners/community files etc. 

The team is already created per: https://github.com/knative/community/blob/main/peribolos/knative-extensions-OWNERS_ALIASES#L116-L121. To leverage the alias in owners.  

We can use exclude lists to drop unnecessary updates as needed for the `func-go`.

/hold
Adding hold for evaluating if it's needed in the repository. 

/cc @matzew @lkingland @matejvasek 