### PR TITLE
Add eventing-rabbitmq integration back 

### DIFF
--- a/repos.yaml
+++ b/repos.yaml
@@ -160,7 +160,7 @@
   meta-organization: 'knative-extensions'
   fork: 'knative-automation/eventing-rabbitmq'
   channel: 'knative-eventing'
-  assignees: knative-extensions/eventing-writers
+  assignees: knative-extensions/eventing-rabbitmq-approvers
 - name: 'knative-extensions/eventing-redis'
   meta-organization: 'knative-extensions'
   fork: 'knative-automation/eventing-redis'

--- a/repos.yaml
+++ b/repos.yaml
@@ -156,6 +156,11 @@
   fork: 'knative-automation/eventing-natss'
   channel: 'knative-eventing'
   assignees: knative-extensions/eventing-writers
+- name: 'knative-extensions/eventing-rabbitmq'
+  meta-organization: 'knative-extensions'
+  fork: 'knative-automation/eventing-rabbitmq'
+  channel: 'knative-eventing'
+  assignees: knative-extensions/eventing-writers
 - name: 'knative-extensions/eventing-redis'
   meta-organization: 'knative-extensions'
   fork: 'knative-automation/eventing-redis'
@@ -283,7 +288,7 @@
   fork: 'knative-automation/func-go'
   channel: 'knative-functions'
   assignees: 'knative-extensions/function-runtime-approvers'
-
+  
 # knative-extensions (backstage)
 - name: 'knative-extensions/backstage-plugins'
   meta-organization: 'knative-extensions'

--- a/repos.yaml
+++ b/repos.yaml
@@ -288,7 +288,7 @@
   fork: 'knative-automation/func-go'
   channel: 'knative-functions'
   assignees: 'knative-extensions/function-runtime-approvers'
-  
+
 # knative-extensions (backstage)
 - name: 'knative-extensions/backstage-plugins'
   meta-organization: 'knative-extensions'


### PR DESCRIPTION
Add this repo back so we restart some automation

Part of https://github.com/knative/eventing/issues/7670


/assign @knative-extensions/eventing-rabbitmq-approvers 


