### PR TITLE
Remove archived knative-extensions/net-certmanager repository

### DIFF
--- a/.github/workflows/update-nightlies.yaml
+++ b/.github/workflows/update-nightlies.yaml
@@ -32,7 +32,6 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         nightly:
-        - net-certmanager
         - net-contour
         - net-istio
         - net-kourier
@@ -45,15 +44,6 @@ jobs:
 
         # Map to nightly-specific parameters.
         include:
-        - nightly: net-certmanager
-          module: knative.dev/net-certmanager
-          directory: ./third_party/cert-manager-latest
-          files: net-certmanager.yaml
-          bucket: net-certmanager
-          repository: knative/serving
-          fork: serving
-          channel: net-certmanager
-          assignee: "@knative/serving-writers"
         - nightly: net-contour
           module: knative.dev/net-contour
           directory: ./third_party/contour-latest

--- a/repos.yaml
+++ b/repos.yaml
@@ -194,11 +194,6 @@
   fork: 'knative-automation/net-istio'
   channel: 'knative-serving-bots'
   assignees: knative-extensions/serving-writers
-- name: 'knative-extensions/net-certmanager'
-  meta-organization: 'knative-extensions'
-  fork: 'knative-automation/net-certmanager'
-  channel: 'knative-serving-bots'
-  assignees: knative-extensions/serving-writers
 - name: 'knative-extensions/net-gateway-api'
   meta-organization: 'knative-extensions'
   fork: 'knative-automation/net-gateway-api'


### PR DESCRIPTION
# Changes
- Remove archived knative-extensions/net-certmanager repository

Partially https://github.com/knative/community/issues/1563