### PR TITLE
Create target dir if it does not exist in update-nightlies

### DIFF
--- a/.github/workflows/update-nightlies.yaml
+++ b/.github/workflows/update-nightlies.yaml
@@ -134,7 +134,7 @@ jobs:
       id: nightlies
       run: |
         for x in ${{ matrix.files }}; do
-          curl https://storage.googleapis.com/knative-nightly/${{ matrix.bucket }}/latest/$x > ${GITHUB_WORKSPACE}/${{ matrix.directory }}/$x
+          curl https://storage.googleapis.com/knative-nightly/${{ matrix.bucket }}/latest/$x --create-dirs -o ${GITHUB_WORKSPACE}/${{ matrix.directory }}/$x
         done
 
         function release_labels() {


### PR DESCRIPTION
One of the [current update-nightlies jobs](https://github.com/knative-extensions/knobots/actions/runs/10771910994/job/29868428658) fails, as the target directory does not exist yet in the repository. 

```
Run for x in eventing-crds.yaml eventing-core.yaml; do
/home/runner/work/_temp/37d75833-0c7e-49d8-89c7-2673193c8cad.sh: line 2: /home/runner/work/knobots/knobots/./third_party/eventing-latest/eventing-crds.yaml: No such file or directory
Error: Process completed with exit code 1.
```

This PR addresses it and updates the CURL command to create the needed directories if they don't exist.