### PR TITLE
Bump go version  in Dockerfiles

### DIFF
--- a/actions/calculate-matrix/Dockerfile
+++ b/actions/calculate-matrix/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # TODO: figure out how to template this.
-FROM golang:1.22
+FROM golang:1.23
 
 RUN go install github.com/bronze1man/yaml2json@latest && apt-get update && apt-get install -y jq
 

--- a/actions/update-actions/Dockerfile
+++ b/actions/update-actions/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # TODO: figure out how to template this.
-FROM golang:1.22
+FROM golang:1.23
 
 RUN go install github.com/bronze1man/yaml2json@latest && apt-get update && apt-get install -y jq
 

--- a/actions/update-deps/Dockerfile
+++ b/actions/update-deps/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # TODO: figure out how to template this.
-FROM golang:1.22
+FROM golang:1.23
 
 RUN go install github.com/google/ko@latest
 RUN go install github.com/google/go-licenses@latest

--- a/actions/update-gofmt/Dockerfile
+++ b/actions/update-gofmt/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # TODO: figure out how to template this.
-FROM golang:1.22
+FROM golang:1.23
 
 RUN go install golang.org/x/tools/cmd/goimports@latest
 

--- a/actions/update-misspell/Dockerfile
+++ b/actions/update-misspell/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # TODO: figure out how to template this.
-FROM golang:1.22
+FROM golang:1.23
 
 RUN go install github.com/client9/misspell/cmd/misspell@latest
 


### PR DESCRIPTION
Bumps the Go version used in the Dockerfiles  to 1.23 in order to be in sync with https://github.com/knative/actions/tree/main/setup-go