### PR TITLE
Remove deprecated client-pkg repository from config

### DIFF
--- a/repos.yaml
+++ b/repos.yaml
@@ -46,11 +46,6 @@
   fork: 'knative-automation/client'
   channel: 'knative-client'
   assignees: knative/client-wg-leads
-- name: 'knative/client-pkg'
-  meta-organization: 'knative'
-  fork: 'knative-automation/client-pkg'
-  channel: 'knative-client'
-  assignees: knative/client-wg-leads
 - name: 'knative/homebrew-client'
   meta-organization: 'knative'
   fork: 'knative-automation/homebrew-client'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Remove deprecated client-pkg repository from config

Not used anymore, therefore we don't need updates machinery to executed on it. 

/cc @dprotaso @cardil @gauron99 
