### PR TITLE
disable serving progressive rollouts dep bump

### DIFF
--- a/repos.yaml
+++ b/repos.yaml
@@ -112,7 +112,7 @@
   meta-organization: 'knative-extensions'
   fork: 'knative-automation/sample-source'
   channel: 'knative-eventing'
-  assignees: knative-extensions/eventing-writers lberk
+  assignees: knative-extensions/eventing-writers
 
 # knative-extensions/eventing-* (eventing), sorted alphabetically
 - name: 'knative-extensions/eventing-autoscaler-keda'


### PR DESCRIPTION
The failed dep update has been spamming the channel for two weeks and it doesn't seem like anyone is going to fix it at this moment.

 Disable it for now