### PR TITLE
drop progressive serving rollout repo

### DIFF
--- a/repos.yaml
+++ b/repos.yaml
@@ -166,13 +166,6 @@
   channel: 'knative-eventing'
   assignees: knative-extensions/eventing-writers
 
-# knative-extensions (serving-progressive-rollout)
-- name: 'knative-extensions/serving-progressive-rollout'
-  meta-organization: 'knative-extensions'
-  fork: 'knative-automation/serving-progressive-rollout'
-  channel: 'knative-serving'
-  assignees: knative-extensions/serving-progressive-rollout-approvers
-
 # knative-extensions (autoscaler-keda)
 - name: 'knative-extensions/autoscaler-keda'
   meta-organization: 'knative-extensions'


### PR DESCRIPTION
Follow up on - the prior PR did a separate clean up - https://github.com/knative-extensions/knobots/pull/440